### PR TITLE
chore: bump Hex1b to 0.160.0

### DIFF
--- a/GUNRPG.ConsoleClient/GUNRPG.ConsoleClient.csproj
+++ b/GUNRPG.ConsoleClient/GUNRPG.ConsoleClient.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="0.124.0" />
+    <PackageReference Include="Hex1b" Version="0.160.0" />
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps the `Hex1b` PackageReference in `GUNRPG.ConsoleClient` from **0.124.0 → 0.160.0** (latest at time of writing).

Filed in coordination with the Hex1b verification tracking issue: mitchdenny/hex1b#339.

## Verification

- ✅ `dotnet restore` resolves 0.160.0 cleanly.
- ✅ `dotnet build GUNRPG.slnx` succeeds, **0 errors and no new warnings**. The 3 pre-existing warnings (`CS8604` in `ReplayVerifier`, `CS8601` in `LiteDbCombatSessionStoreTests`, `xUnit2013` in `DistributedAuthorityTests`) are unchanged.
- ✅ No new `HEX1B0001`–`HEX1B0009` analyzer diagnostics on consumer code in `GUNRPG.ConsoleClient/Program.cs` or `GUNRPG.Tests/SessionAuthTests.cs`.
- ✅ `dotnet test`: **1476/1476 passing** on clean runs. A handful of pre-existing flakes appear intermittently (LiteDB concurrency, stochastic accuracy, renderer tests under parallel pressure, device-code polling timing) — they affect the baseline (0.124.0) too and are unrelated to Hex1b.
- ✅ Console client startup verified — `Hex1bApp` constructs successfully against the new package (reaches `EnterRawModeAsync` before exiting on the non-TTY harness used for automation).

## What's in this PR

- A single line change in `GUNRPG.ConsoleClient/GUNRPG.ConsoleClient.csproj`.
- No source changes required in your TUI code — the upgrade is fully source-compatible.

Marked as **draft** so you can take it on whatever timeline works for you. Happy to convert to ready-for-review or close it if you'd prefer to bump on your own schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to version 0.160.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->